### PR TITLE
Rendering password settings in content if < Craft 3.2.9

### DIFF
--- a/src/PasswordProtection.php
+++ b/src/PasswordProtection.php
@@ -260,7 +260,13 @@ class PasswordProtection extends Plugin
         }
 
         $view = Craft::$app->getView();
-        $view->hook('cp.entries.edit.settings', [$this, 'renderEditSourceLink']);
+
+        // render the options in the entry settings sidebar if possible,
+        // otherwise render at the end of the content.
+        $isLaterThan329 = version_compare(Craft::$app->version, "3.2.9", ">=");
+        $hookHandle = $isLaterThan329 ? "cp.entries.edit.settings" : "cp.entries.edit.content";
+        
+        $view->hook($hookHandle, [$this, 'renderEditSourceLink']);
     }
 
     /**

--- a/src/PasswordProtection.php
+++ b/src/PasswordProtection.php
@@ -32,7 +32,10 @@ use craft\elements\Entry;
 use craft\events\RegisterElementActionsEvent;
 use craft\events\RegisterTemplateRootsEvent;
 
+use craft\services\Elements;
+
 use yii\base\Event;
+use yii\base\UserException;
 
 /**
  * Craft plugins are very much like little applications in and of themselves. We’ve made
@@ -181,6 +184,29 @@ class PasswordProtection extends Plugin
         //     }
         // );
 
+        // after an element has been saved, if it was an entry, update any
+        // password information required on the entry.
+        Event::on(
+			Elements::class,
+			Elements::EVENT_AFTER_SAVE_ELEMENT,
+			function ($event) {
+
+                try {
+
+                    $element = $event->element;
+
+                    if (is_a($element, "craft\\elements\\Entry")) {
+                        $entryId = $event->element->id;
+                        (new PasswordProtectionService())->updateEntryField(Craft::$app->request->getBodyParams(), $entryId);
+                    }
+
+                } catch (\Throwable $th) {
+                    throw $th;
+                }
+
+			}
+		);
+
         // Register our variables
         Event::on(
             CraftVariable::class,
@@ -250,22 +276,13 @@ class PasswordProtection extends Plugin
      */
     protected function executeLogic()
     {
-        $request = Craft::$app->getRequest();
-
-        //Saving the entry password
-        if ($request->isCpRequest && $request->isActionRequest && in_array('entries', $request->getActionSegments())
-        && in_array('save-entry', $request->getActionSegments())) {
-            $service = new PasswordProtectionService();
-            $service->updateEntryField($request->getBodyParams());
-        }
-
-        $view = Craft::$app->getView();
-
+        
         // render the options in the entry settings sidebar if possible,
         // otherwise render at the end of the content.
         $isLaterThan329 = version_compare(Craft::$app->version, "3.2.9", ">=");
         $hookHandle = $isLaterThan329 ? "cp.entries.edit.settings" : "cp.entries.edit.content";
         
+        $view = Craft::$app->getView();
         $view->hook($hookHandle, [$this, 'renderEditSourceLink']);
     }
 

--- a/src/services/PasswordProtectionService.php
+++ b/src/services/PasswordProtectionService.php
@@ -16,7 +16,6 @@ use Imarc\Craft\PasswordProtection\Records\PasswordProtectionRecord;
 use Craft;
 use craft\base\Component;
 use Exception;
-use \yii\base\UserException;
 
 /**
  * PasswordProtectionService Service
@@ -38,22 +37,13 @@ class PasswordProtectionService extends Component
 
     /**
      * This function will handle the saving of passwordEnable and the password.
-     * 
-     * @param array $params - password settings to be saved
-     * @param mixed $entryId - the id of the entry to save the password
-     * information against
      *
      * @return mixed
      */
-    public function updateEntryField($params, $entryId = null) {
+    public function updateEntryField($params) {
         $settings = PasswordProtection::$plugin->getSettings();
 
-        $entryId = $entryId ?? $params['entryId'] ?? null;
-
-        if ($entryId === null) {
-            throw new UserException("Couldn't save password on entry, as entryId is null");
-        }
-
+        $entryId = $params['entryId'] ?? null;
         $passwordProtectionEnabled = empty($params['imarc_passwordProtectionEnabled']) ? false : true;
         $password = $params['imarc_password'] ?? '';
 

--- a/src/services/PasswordProtectionService.php
+++ b/src/services/PasswordProtectionService.php
@@ -16,6 +16,7 @@ use Imarc\Craft\PasswordProtection\Records\PasswordProtectionRecord;
 use Craft;
 use craft\base\Component;
 use Exception;
+use \yii\base\UserException;
 
 /**
  * PasswordProtectionService Service
@@ -37,13 +38,22 @@ class PasswordProtectionService extends Component
 
     /**
      * This function will handle the saving of passwordEnable and the password.
+     * 
+     * @param array $params - password settings to be saved
+     * @param mixed $entryId - the id of the entry to save the password
+     * information against
      *
      * @return mixed
      */
-    public function updateEntryField($params) {
+    public function updateEntryField($params, $entryId = null) {
         $settings = PasswordProtection::$plugin->getSettings();
 
-        $entryId = $params['entryId'] ?? null;
+        $entryId = $entryId ?? $params['entryId'] ?? null;
+
+        if ($entryId === null) {
+            throw new UserException("Couldn't save password on entry, as entryId is null");
+        }
+
         $passwordProtectionEnabled = empty($params['imarc_passwordProtectionEnabled']) ? false : true;
         $password = $params['imarc_password'] ?? '';
 


### PR DESCRIPTION
as per #1, the `cp.entries.edit.settings` hook was only introduced on Craft 3.2.9, so the entry options don't display on older versions of Craft.

I've added a conditional so that if we're on < Craft 3.2.9, the password options will be displayed at the bottom of the entry content rather than in the settings sidebar.