### PR TITLE
use sourceId for newer versions of craft without entryId

### DIFF
--- a/src/services/PasswordProtectionService.php
+++ b/src/services/PasswordProtectionService.php
@@ -43,7 +43,7 @@ class PasswordProtectionService extends Component
     public function updateEntryField($params) {
         $settings = PasswordProtection::$plugin->getSettings();
 
-        $entryId = $params['entryId'] ?? null;
+        $entryId = $params['entryId'] ?? $params['sourceId'] ?? null;
         $passwordProtectionEnabled = empty($params['imarc_passwordProtectionEnabled']) ? false : true;
         $password = $params['imarc_password'] ?? '';
 


### PR DESCRIPTION
Fixes a bug that prevents saving any entries with passwords set. Newer versions of craft don't include entryId in favor of sourceId; this code just checks for both.

See also: https://github.com/craftcms/cms/issues/5087#issuecomment-543902571